### PR TITLE
Add a "Disable Subtitles" toggle

### DIFF
--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -42,6 +42,8 @@
 "osd.subtitle_pos" = "Subtitle Position: %.1f";
 "osd.mute" = "Mute";
 "osd.unmute" = "Unmute";
+"osd.disable_subtitles" = "Subtitles Disabled";
+"osd.enable_subtitles" = "Subtitles Enabled";
 "osd.screenshot" = "Screenshot Captured";
 "osd.abloop.a" = "AB-Loop: A";
 "osd.abloop.b" = "AB-Loop: B";

--- a/iina/Base.lproj/MainMenu.xib
+++ b/iina/Base.lproj/MainMenu.xib
@@ -511,6 +511,9 @@ CA
                                 <modifierMask key="keyEquivalentModifierMask"/>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="EvW-J9-wqJ"/>
+                            <menuItem title="Disable Subtitles" id="7kN-KF-Pba">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                            </menuItem>
                             <menuItem title="Cycle Subtitles" tag="2" id="sgu-dK-IGE">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                             </menuItem>
@@ -689,6 +692,7 @@ CA
                 <outlet property="deinterlace" destination="yHI-7D-OaI" id="Z8n-z4-52B"/>
                 <outlet property="deleteCurrentFile" destination="npH-8B-XA4" id="23t-fO-TbK"/>
                 <outlet property="delogo" destination="ArE-2s-JIV" id="zzg-gr-TsG"/>
+                <outlet property="disableSubtitles" destination="7kN-KF-Pba" id="RT2-kv-iV5"/>
                 <outlet property="doubleSize" destination="Hal-18-Tnf" id="vnl-Rb-Y3o"/>
                 <outlet property="encodingMenu" destination="Pf6-5i-B1E" id="Gat-gG-pkT"/>
                 <outlet property="fileLoop" destination="D1y-kv-85s" id="xSv-oo-UJa"/>

--- a/iina/IINACommand.swift
+++ b/iina/IINACommand.swift
@@ -35,5 +35,6 @@ enum IINACommand: String {
 
   case findOnlineSubs = "find-online-subs"
   case saveDownloadedSub = "save-downloaded-sub"
+  case disableSubtitles = "disable-subtitles"
 
 }

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -750,11 +750,21 @@ class MPVController: NSObject {
 
     case MPVOption.TrackSelection.sid:
       player.info.sid = Int(getInt(MPVOption.TrackSelection.sid))
+      if player.info.sid != 0 && player.info.subDisabled == true {
+        player.info.subDisabled = false
+      } else if player.info.sid == 0 && player.info.secondSid == 0 {
+        player.info.subDisabled = true
+      }
       player.postNotification(.iinaSIDChanged)
       player.sendOSD(.track(player.info.currentTrack(.sub) ?? .noneSubTrack))
 
     case MPVOption.Subtitles.secondarySid:
       player.info.secondSid = Int(getInt(MPVOption.Subtitles.secondarySid))
+      if player.info.secondSid != 0 && player.info.subDisabled == true {
+        player.info.subDisabled = false
+      } else if player.info.sid == 0 && player.info.secondSid == 0 {
+        player.info.subDisabled = true
+      }
       player.postNotification(.iinaSIDChanged)
 
     case MPVOption.PlaybackControl.pause:

--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -258,10 +258,15 @@ extension MainMenuActionHandler {
 // MARK: - Subtitles
 
 extension MainMenuActionHandler {
-  @objc func menuToggleSubtitle(_ sender: NSMenuItem) {
-    
+
+  @objc func menuToggleDisableSubtitles(_ sender: NSMenuItem) {
+    if !player.info.subDisabled {
+      player.toggleDisableSubtitles(true)
+    } else {
+      player.toggleDisableSubtitles(false)
+    }
   }
-  
+
   @objc func menuLoadExternalSub(_ sender: NSMenuItem) {
     Utility.quickOpenPanel(title: "Load external subtitle file", chooseDir: false) { url in
       self.player.loadExternalSubFile(url, delay: true)

--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -141,7 +141,6 @@ class MenuController: NSObject, NSMenuDelegate {
   // Subtitle
   @IBOutlet weak var subMenu: NSMenu!
   @IBOutlet weak var quickSettingsSub: NSMenuItem!
-  @IBOutlet weak var toggleSubtitles: NSMenuItem!
   @IBOutlet weak var cycleSubtitles: NSMenuItem!
   @IBOutlet weak var subTrackMenu: NSMenu!
   @IBOutlet weak var secondSubTrackMenu: NSMenu!
@@ -343,6 +342,7 @@ class MenuController: NSObject, NSMenuDelegate {
     loadExternalSub.action = #selector(MainMenuActionHandler.menuLoadExternalSub(_:))
     subTrackMenu.delegate = self
     secondSubTrackMenu.delegate = self
+    disableSubtitles.action = #selector(MainMenuActionHandler.menuToggleDisableSubtitles(_:))
 
     findOnlineSub.action = #selector(MainMenuActionHandler.menuFindOnlineSub(_:))
     saveDownloadedSub.action = #selector(MainMenuActionHandler.saveDownloadedSub(_:))
@@ -477,6 +477,7 @@ class MenuController: NSObject, NSMenuDelegate {
 
   private func updateSubMenu() {
     let player = PlayerCore.active
+    disableSubtitles.state = player.info.subDisabled ? .on : .off
     subDelayIndicator.title = String(format: NSLocalizedString("menu.sub_delay", comment: "Subtitle Delay:"), player.info.subDelay)
 
     let encodingCode = player.info.subEncoding ?? "auto"
@@ -680,6 +681,7 @@ class MenuController: NSObject, NSMenuDelegate {
       (resetSubDelay, false, ["set", "sub-delay", "0"], true, nil, nil),
       (increaseTextSize, false, ["multiply", "sub-scale", "1.1"], true, 1.01...1.49, nil),
       (decreaseTextSize, false, ["multiply", "sub-scale", "0.9"], true, 0.71...0.99, nil),
+      (disableSubtitles, true, ["disable-subtitles"], false, nil, nil),
       (resetTextSize, false, ["set", "sub-scale", "1"], true, nil, nil),
       (alwaysOnTop, false, ["cycle", "ontop"], false, nil, nil),
       (fullScreen, false, ["cycle", "fullscreen"], false, nil, nil)

--- a/iina/OSDMessage.swift
+++ b/iina/OSDMessage.swift
@@ -62,6 +62,8 @@ enum OSDMessage {
   case addFilter(String)
   case removeFilter
 
+  case disableSubtitles
+  case enableSubtitles
   case startFindingSub(String)  // sub source
   case foundSub(Int)
   case downloadedSub(String)  // filename
@@ -155,6 +157,12 @@ enum OSDMessage {
         String(format: NSLocalizedString("osd.subtitle_pos", comment: "Subtitle Position: %f"), value),
         .withProgress(value / 100)
       )
+
+    case .disableSubtitles:
+      return (NSLocalizedString("osd.subtitles_disabled", comment: "Subtitles Disabled"), .normal)
+
+    case .enableSubtitles:
+      return (NSLocalizedString("osd.subtitles_enabled", comment: "Subtitles Enabled"), .normal)
 
     case .mute:
       return (NSLocalizedString("osd.mute", comment: "Mute"), .normal)

--- a/iina/PlaybackInfo.swift
+++ b/iina/PlaybackInfo.swift
@@ -130,6 +130,9 @@ class PlaybackInfo {
   var sid: Int?
   var vid: Int?
   var secondSid: Int?
+  var savedSid: Int?
+  var savedSecondSid: Int?
+  var subDisabled: Bool = false
 
   var subEncoding: String?
 

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -658,6 +658,32 @@ class PlayerCore: NSObject {
     mpv.setFlag(MPVOption.Video.deinterlace, enable)
   }
 
+  func toggleDisableSubtitles(_ enable: Bool) {
+    // FIXME sendOSD doesn't work here because as soon as a sub track changes,
+    // the property listeners in MPVController will fire their own OSD message
+    // effectively making the ones here unseen
+    if enable {
+      if !info.subDisabled {
+        info.savedSid = info.sid
+        info.savedSecondSid = info.secondSid
+        mpv.setInt(MPVOption.TrackSelection.sid, 0)
+        mpv.setInt(MPVOption.Subtitles.secondarySid, 0)
+        info.subDisabled = true
+        // sendOSD(.disableSubtitles)
+      }
+    } else {
+      mpv.setInt(MPVOption.TrackSelection.sid, info.savedSid ?? 1)
+      mpv.setInt(MPVOption.Subtitles.secondarySid, info.savedSecondSid ?? 0)
+      info.subDisabled = false
+      // sendOSD(.enableSubtitles)
+    }
+  }
+
+  func toggleHardwareDecoding(_ enable: Bool) {
+    let value = Preference.HardwareDecoderOption(rawValue: Preference.integer(for: .hardwareDecoder))?.mpvString ?? "auto"
+    mpv.setString(MPVOption.Video.hwdec, enable ? value : "no")
+  }
+
   enum VideoEqualizerType {
     case brightness, contrast, saturation, gamma, hue
   }

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -489,6 +489,8 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
       menuActionHandler.menuFindOnlineSub(.dummy)
     case .saveDownloadedSub:
       menuActionHandler.saveDownloadedSub(.dummy)
+    case .disableSubtitles:
+      menuActionHandler.menuToggleDisableSubtitles(.dummy)
     default:
       break
     }

--- a/iina/config/iina-default-input.conf
+++ b/iina/config/iina-default-input.conf
@@ -73,6 +73,7 @@ X add sub-delay 0.5
 Alt+Z add sub-delay -0.1
 Alt+X add sub-delay 0.1
 C set sub-delay 0
+#@iina Ctrl+v disable-subtitles
 
 ESC set fullscreen no
 ENTER set fullscreen yes

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -42,6 +42,8 @@
 "osd.subtitle_pos" = "Subtitle Position: %.1f";
 "osd.mute" = "Mute";
 "osd.unmute" = "Unmute";
+"osd.disable_subtitles" = "Subtitles Disabled";
+"osd.enable_subtitles" = "Subtitles Enabled";
 "osd.screenshot" = "Screenshot Captured";
 "osd.abloop.a" = "AB-Loop: A";
 "osd.abloop.b" = "AB-Loop: B";


### PR DESCRIPTION
- [x] This change has been discussed with the author.
- [ ] It implements / fixes issue #.

---

**Description:**
This is a very early version of the toggle. It sets subs to None when enabled, restores the previously selected tracks when disabled. Currently mapped as a default IINA command to the "Ctrl+v" shortcut and to the menu item "Disable Subtitles" under the Subtitles menu. It will update it's status automatically to On if the user manually sets both sub tracks to None. In that case, when the toggle is activated, it will set --sid=1 and --secondary-sid=0 by default. It will also automatically resets to Off whenever the user manually activates a subtitle track.